### PR TITLE
Use lazy dual string/Buffer representation for trace IDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
 -include crossdock/rules.mk
 
 .PHONY: publish
-publish:
-	npm run compile
+publish: build-node
 	npm version $(shell ./scripts/version_prompt.sh)
 	git push  --set-upstream origin $(shell bash -c "git rev-parse --abbrev-ref HEAD")
 	git push origin --tags

--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ with Zipkin-compatible data model.
 
 ## Developing
 
- 1. `git submodule init update`
- 2. `npm test`
- 3. `make build-node`
+ 1. `git submodule update --init`
+ 2. `npm install`
+ 3. `npm test`
+ 4. `make build-node`
 
   [ci-img]: https://travis-ci.org/uber/jaeger-client-node.svg?branch=master
   [cov-img]: https://coveralls.io/repos/github/uber/jaeger-client-node/badge.svg?branch=master

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ with Zipkin-compatible data model.
 
  1. `git submodule init update`
  2. `npm test`
+ 3. `make build-node`
 
   [ci-img]: https://travis-ci.org/uber/jaeger-client-node.svg?branch=master
   [cov-img]: https://coveralls.io/repos/github/uber/jaeger-client-node/badge.svg?branch=master

--- a/benchmarks/flame_graph_loop.js
+++ b/benchmarks/flame_graph_loop.js
@@ -19,17 +19,21 @@
 // THE SOFTWARE.
 
 var ConstSampler = require('../dist/src/samplers/const_sampler.js').default;
-var InMemoryReporter = require('../dist/src/reporters/in_memory_reporter.js').default;
+var RemoteReporter = require('../dist/src/reporters/remote_reporter.js').default;
+var NoopReporter = require('../dist/src/reporters/noop_reporter.js').default;
 var Tracer = require('../dist/src/tracer.js').default;
 var opentracing = require('opentracing');
+var argv = require('minimist')(process.argv.slice(2));
 
-function server_client_span_loop(tracer) {
+function server_client_span_loop(tracer, carrier) {
     for ( var i = 0; i <= 0; i--) {
         // deserialize parent context from carrier
-        var parentContext = tracer.extract(opentracing.FORMAT_HTTP_HEADERS, {});
+        var parentContext = tracer.extract(opentracing.FORMAT_HTTP_HEADERS, carrier);
 
         // create server span from parent context
-        var serverSpan = tracer.startSpan('server-span');
+        var serverSpan = tracer.startSpan('server-span', {
+            childOf: parentContext
+        });
 
         // create client span
         var clientSpan = tracer.startSpan('client-span', {
@@ -39,15 +43,42 @@ function server_client_span_loop(tracer) {
         tracer.inject(clientSpan.context(), opentracing.FORMAT_HTTP_HEADERS, {});
         // finish client span
         clientSpan.finish();
+
         // finish server span
         serverSpan.finish();
     }
 }
 
+console.dir(argv);
+
+var reporter = new NoopReporter();
+if (argv.r == "udp") {
+    console.log("Using Remote Reporter");
+    reporter = new RemoteReporter();
+} else {
+    console.log("Using Noop Reporter");
+}
+
+var sampler = new ConstSampler(false);
+var flag = "0";
+if (argv.s) {
+    console.log("Sampling is at 100%");
+    sampler = new ConstSampler(true);
+    flag = "1";
+} else {
+    console.log("Sampling is off");
+}
+
 var tracer = new Tracer(
     'flamegraph-tracer',
-    new InMemoryReporter(),
-    new ConstSampler(true)
+    reporter,
+    sampler
 );
 
-server_client_span_loop(tracer);
+var carrier = {
+    "uber-trace-id": "123:123:0:" + flag
+};
+
+console.dir(carrier);
+
+server_client_span_loop(tracer, carrier);

--- a/benchmarks/span_context.js
+++ b/benchmarks/span_context.js
@@ -22,14 +22,14 @@ var _ = require('lodash');
 var Benchmark = require('benchmark');
 var benchmarks = require('beautify-benchmark');
 var ConstSampler = require('../dist/src/samplers/const_sampler.js').default;
-var InMemoryReporter = require('../dist/src/reporters/in_memory_reporter.js').default;
+var NoopReporter = require('../dist/src/reporters/noop_reporter.js').default;
 var SpanContext = require('../dist/src/span_context.js').default;
 var Tracer = require('../dist/src/tracer.js').default;
 
 function benchmarkSpanContext() {
     console.log('Beginning Span Context Benchmark...');
 
-    var tracer = new Tracer('const-tracer', new InMemoryReporter(), new ConstSampler(true));
+    var tracer = new Tracer('const-tracer', new NoopReporter(), new ConstSampler(true));
     var span = tracer.startSpan('op-name');
     var context = span.context();
 

--- a/dist/package.json
+++ b/dist/package.json
@@ -1,10 +1,15 @@
 {
   "name": "jaeger-client",
-  "version": "0.0.1",
-  "description": "client for jaeger node",
+  "version": "0.1.0",
+  "description": "Jaeger binding for OpenTracing Node",
+  "licence": "MIT",
   "keywords": [],
   "author": "oibe <oibe@uber.com>",
-  "main": "./dist/index.js",
+  "main": "./dist/src/index.js",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/uber/jaeger-client-node.git"
+  },
   "contributors": [
     {
       "name": "oibe"
@@ -30,6 +35,7 @@
     "body-parser": "^1.15.2",
     "buffer-equal": "^1.0.0",
     "chai": "^3.5.0",
+    "coveralls": "^2.11.14",
     "eslint": "^2.4.0",
     "eslint-config-airbnb": "^6.2.0",
     "eslint-plugin-flowtype": "^2.4.0",
@@ -37,6 +43,7 @@
     "express": "^4.14.0",
     "flow-bin": "^0.30.0",
     "lodash": "^4.15.0",
+    "minimist": "1.2.0",
     "mocha": "^3.0.1",
     "opentracing": "git://github.com/opentracing/opentracing-javascript.git#575e8149aadba97d27e9cadff3b8e47a15c2db09",
     "rsvp": "^3.3.1",
@@ -50,11 +57,12 @@
     "copy-submodule": "git submodule init -- ./src/jaeger-idl && cp -R ./src/jaeger-idl ./dist/src/ && rm -rf ./dist/src/jaeger-idl/.git",
     "check-ls": "npm ls --loglevel=http --parseable 1>/dev/null && echo '# npm is in a good state'",
     "cover": "./node_modules/.bin/babel-node ./node_modules/.bin/babel-istanbul cover ./node_modules/.bin/_mocha -- test/",
+    "coveralls": "cat ./coverage/lcov.info | coveralls",
     "flow": "flow; test $? -eq 0 -o $? -eq 2",
     "lint": "eslint $(ls src/ | grep '.js$') && echo '# linter passed'",
-    "report-cover": "nyc report --reporter html --reporter text",
+    "lint-ci": "npm run lint && echo '# TODO: ADD npm run check-license'",
     "test": "npm run flow & npm run lint && ./node_modules/mocha/bin/mocha --compilers js:babel-core/register",
-    "check-cover": "nyc check-coverage --branches=10 --lines=10 --functions=10",
-    "view-cover": "opn ./coverage/index.html"
+    "test-ci": "npm run test && npm run lint-ci && npm run cover",
+    "show-cover": "open coverage/lcov-report/index.html"
   }
 }

--- a/dist/src/constants.js
+++ b/dist/src/constants.js
@@ -60,7 +60,3 @@ var SAMPLER_TYPE_REMOTE = exports.SAMPLER_TYPE_REMOTE = 'remote';
 // The value of the header is recorded as the tag on the root span, so that the
 // trace can be found in the UI using this value as a correlation ID.
 var JAEGER_DEBUG_HEADER = exports.JAEGER_DEBUG_HEADER = 'jaeger-debug-id';
-
-// EMIT_SPAN_BATCH_OVERHEAD is the rough estimate of header space taken up in a
-// thrift frame.
-var EMIT_SPAN_BATCH_OVERHEAD = exports.EMIT_SPAN_BATCH_OVERHEAD = 30;

--- a/dist/src/test_util.js
+++ b/dist/src/test_util.js
@@ -1,0 +1,210 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+var _lodash = require('lodash');
+
+var _lodash2 = _interopRequireDefault(_lodash);
+
+var _bufferEqual = require('buffer-equal');
+
+var _bufferEqual2 = _interopRequireDefault(_bufferEqual);
+
+var _opentracing = require('opentracing');
+
+var _opentracing2 = _interopRequireDefault(_opentracing);
+
+var _span = require('./span.js');
+
+var _span2 = _interopRequireDefault(_span);
+
+var _util = require('./util.js');
+
+var _util2 = _interopRequireDefault(_util);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var TestUtils = function () {
+    function TestUtils() {
+        _classCallCheck(this, TestUtils);
+    }
+
+    _createClass(TestUtils, null, [{
+        key: 'traceIdEqual',
+        value: function traceIdEqual(span, traceId) {
+            var spanTraceId = span.context().traceId;
+            if (spanTraceId == null && traceId == null) {
+                return true;
+            }
+
+            return (0, _bufferEqual2.default)(spanTraceId, _util2.default.encodeInt64(traceId));
+        }
+    }, {
+        key: 'spanIdEqual',
+        value: function spanIdEqual(span, spanId) {
+            var spanContextId = span.context().spanId;
+            if (spanContextId == null && spanId == null) {
+                return true;
+            }
+
+            return (0, _bufferEqual2.default)(spanContextId, _util2.default.encodeInt64(spanId));
+        }
+    }, {
+        key: 'parentIdEqual',
+        value: function parentIdEqual(span, parentId) {
+            var spanParentId = span.context().parentId;
+            if (spanParentId == null && parentId == null) {
+                return true;
+            }
+
+            return (0, _bufferEqual2.default)(spanParentId, _util2.default.encodeInt64(parentId));
+        }
+    }, {
+        key: 'flagsEqual',
+        value: function flagsEqual(span, flags) {
+            var spanFlagsId = span.context().flags;
+            return spanFlagsId === flags;
+        }
+    }, {
+        key: 'operationNameEqual',
+        value: function operationNameEqual(span, operationName) {
+            return span._operationName === operationName;
+        }
+    }, {
+        key: 'startTimeEqual',
+        value: function startTimeEqual(span, startTime) {
+            return span._startTime === startTime;
+        }
+    }, {
+        key: 'durationEqual',
+        value: function durationEqual(span, duration) {
+            return span._duration === duration;
+        }
+    }, {
+        key: 'hasTags',
+        value: function hasTags(span, tags) {
+            // TODO(oibe) make this work for duplicate tags
+            var expectedTags = {};
+            for (var i = 0; i < span._tags.length; i++) {
+                var key = span._tags[i].key;
+                var value = span._tags[i].value;
+                expectedTags[key] = value;
+            }
+
+            for (var tag in tags) {
+                if (tags.hasOwnProperty(tag) && !(tag in expectedTags)) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }, {
+        key: 'hasLogs',
+        value: function hasLogs(span, logs) {
+            /*
+            1.) This method does not work if span logs have nested objects...
+            2.)  This is hard to make linear because if an object does not have a guaranteed order
+                  then I cannot stringify a log, and use it as a key in a hashmap.  So its safer to compare object
+                  equality with a O(n^2) which is only used for testing.
+            */
+            for (var i = 0; i < logs.length; i++) {
+                var expectedLog = span._logs[i];
+                var found = false;
+                for (var j = 0; j < span._logs.length; j++) {
+                    var spanLog = span._logs[j];
+                    if (_lodash2.default.isEqual(spanLog, expectedLog)) {
+                        found = true;
+                    }
+                }
+                if (!found) {
+                    return false;
+                }
+                found = false;
+            }
+
+            return true;
+        }
+    }, {
+        key: 'isClient',
+        value: function isClient(span) {
+            var tag = {};
+            tag[_opentracing2.default.Tags.SPAN_KIND] = _opentracing2.default.Tags.SPAN_KIND_RPC_CLIENT;
+            return TestUtils.hasTags(span, tag);
+        }
+    }, {
+        key: 'hasBaggage',
+        value: function hasBaggage(span, baggage) {
+            var found = false;
+            for (var key in baggage) {
+                found = span.getBaggageItem(key);
+                if (!found) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }, {
+        key: 'isDebug',
+        value: function isDebug(span) {
+            return span.context().isDebug();
+        }
+    }, {
+        key: 'isSampled',
+        value: function isSampled(span) {
+            return span.context().isSampled();
+        }
+    }, {
+        key: 'carrierHasTracerState',
+        value: function carrierHasTracerState(carrier) {
+            var tracerState = carrier['uber-trace-id'];
+            return tracerState !== null && tracerState !== undefined;
+        }
+    }, {
+        key: 'carrierHasBaggage',
+        value: function carrierHasBaggage(carrier, baggage) {
+            var prefix = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 'uberctx-';
+
+            for (var key in baggage) {
+                if (baggage.hasOwnProperty(key)) {
+                    var prefixKey = prefix + key;
+                    if (!(prefixKey in carrier)) {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+    }]);
+
+    return TestUtils;
+}();
+
+exports.default = TestUtils;

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "express": "^4.14.0",
     "flow-bin": "^0.30.0",
     "lodash": "^4.15.0",
+    "minimist": "1.2.0",
     "mocha": "^3.0.1",
     "opentracing": "git://github.com/opentracing/opentracing-javascript.git#575e8149aadba97d27e9cadff3b8e47a15c2db09",
     "rsvp": "^3.3.1",

--- a/src/span_context.js
+++ b/src/span_context.js
@@ -190,6 +190,12 @@ export default class SpanContext {
             return null;
         }
 
+        // Note: Number type in JS cannot represent the full range of 64bit unsigned ints,
+        // so using parseInt() on strings representing 64bit hex numbers only returns
+        // an approximation of the actual value. Fortunately, we do not depend on parsing
+        // the IDs with parseInt(), we are only using it to validate that the string is
+        // a valid hex number (which is faster than doing it manually).  We cannot use
+        // Int64(numberValue).toBuffer() because it throws exceptions on bad strings.
         let approxTraceId = parseInt(headers[0], 16);
         let NaNDetected = (isNaN(approxTraceId, 16) || approxTraceId === 0) ||
                           isNaN(parseInt(headers[1], 16)) ||

--- a/src/span_context.js
+++ b/src/span_context.js
@@ -27,6 +27,9 @@ export default class SpanContext {
     _traceId: any;
     _spanId: any;
     _parentId: any;
+    _traceIdStr: ?string;
+    _spanIdStr: ?string;
+    _parentIdStr: ?string;
     _flags: number;
     _baggage: any;
     _debugId: ?string;
@@ -34,27 +37,63 @@ export default class SpanContext {
     constructor(traceId: any,
                 spanId: any,
                 parentId: any,
+                traceIdStr: ?string,
+                spanIdStr: ?string,
+                parentIdStr: ?string,
                 flags: number,
                 baggage: any = {},
                 debugId: ?string = '') {
         this._traceId = traceId;
         this._spanId = spanId;
         this._parentId = parentId;
+        this._traceIdStr = traceIdStr;
+        this._spanIdStr = spanIdStr;
+        this._parentIdStr = parentIdStr;
         this._flags = flags;
         this._baggage = baggage;
         this._debugId = debugId;
     }
 
     get traceId(): any {
+        if (this._traceId == null && this._traceIdStr != null) {
+            this._traceId = Utils.encodeInt64(this._traceIdStr);
+        }
         return this._traceId;
     }
 
     get spanId(): any {
+        if (this._spanId == null && this._spanIdStr != null) {
+            this._spanId = Utils.encodeInt64(this._spanIdStr);
+        }
         return this._spanId;
     }
 
     get parentId(): any {
+        if (this._parentId == null && this._parentIdStr != null) {
+            this._parentId = Utils.encodeInt64(this._parentIdStr);
+        }
         return this._parentId;
+    }
+
+    get traceIdStr(): ?string {
+        if (this._traceIdStr == null && this._traceId != null) {
+            this._traceIdStr = Utils.removeLeadingZeros(this._traceId.toString('hex'));
+        }
+        return this._traceIdStr;
+    }
+
+    get spanIdStr(): ?string {
+        if (this._spanIdStr == null && this._spanId != null) {
+            this._spanIdStr = Utils.removeLeadingZeros(this._spanId.toString('hex'));
+        }
+        return this._spanIdStr;
+    }
+
+    get parentIdStr(): ?string {
+        if (this._parentIdStr == null && this._parentId != null) {
+            this._parentIdStr = Utils.removeLeadingZeros(this._parentId.toString('hex'));
+        }
+        return this._parentIdStr;
     }
 
     get flags(): number {
@@ -71,14 +110,17 @@ export default class SpanContext {
 
     set traceId(traceId: Buffer): void {
         this._traceId = traceId;
+        this._traceIdStr = null;
     }
 
     set spanId(spanId: Buffer): void {
         this._spanId = spanId;
+        this._spanIdStr = null;
     }
 
     set parentId(parentId: Buffer): void {
         this._parentId = parentId;
+        this._parentIdStr = null;
     }
 
     set flags(flags: number): void {
@@ -111,26 +153,32 @@ export default class SpanContext {
         return (this.flags & constants.DEBUG_MASK) === constants.DEBUG_MASK;
     }
 
+    withBaggageItem(key: string, value: string): SpanContext {
+        let newBaggage = Utils.clone(this._baggage);
+        newBaggage[key] = value;
+        return new SpanContext(
+            this._traceId,
+            this._spanId,
+            this._parentId,
+            this._traceIdStr,
+            this._spanIdStr,
+            this._parentIdStr,
+            this._flags,
+            newBaggage,
+            this._debugId);
+    }
+
     /**
      * @return {string} - returns a string version of this span context.
      **/
     toString(): string {
-        var parentId = this._parentId ? this._parentId.toString('hex') : '0';
-
         return [
-            Utils.removeLeadingZeros(this._traceId.toString('hex')),
-            Utils.removeLeadingZeros(this._spanId.toString('hex')),
-            Utils.removeLeadingZeros(parentId),
+            this.traceIdStr,
+            this.spanIdStr,
+            this.parentIdStr || "0",
             this._flags.toString(16)
         ].join(':');
     }
-
-    withBaggageItem(key: string, value: string): SpanContext {
-        let newBaggage = Utils.clone(this._baggage);
-        newBaggage[key] = value;
-        return new SpanContext(this._traceId, this._spanId, this._parentId, this._flags, newBaggage, this._debugId);
-    }
-
 
     /**
      * @param {string} serializedString - a serialized span context.
@@ -142,8 +190,8 @@ export default class SpanContext {
             return null;
         }
 
-        let traceId = parseInt(headers[0], 16);
-        let NaNDetected = (isNaN(traceId, 16) || traceId === 0) ||
+        let approxTraceId = parseInt(headers[0], 16);
+        let NaNDetected = (isNaN(approxTraceId, 16) || approxTraceId === 0) ||
                           isNaN(parseInt(headers[1], 16)) ||
                           isNaN(parseInt(headers[2], 16)) ||
                           isNaN(parseInt(headers[3], 16));
@@ -154,14 +202,52 @@ export default class SpanContext {
 
         let parentId = null;
         if (headers[2] !== '0') {
-            parentId = Utils.encodeInt64(headers[2]);
+            parentId = headers[2];
         }
 
-        return new SpanContext(
-            Utils.encodeInt64(headers[0]),
-            Utils.encodeInt64(headers[1]),
+        return SpanContext.withStringIds(
+            headers[0],
+            headers[1],
             parentId,
             parseInt(headers[3], 16)
+        );
+    }
+
+    static withBinaryIds(traceId: any,
+                         spanId: any,
+                         parentId: any,
+                         flags: number,
+                         baggage: any = {},
+                         debugId: ?string = '') : SpanContext {
+        return new SpanContext(
+            traceId,
+            spanId,
+            parentId,
+            null, // traceIdStr: string,
+            null, // spanIdStr: string,
+            null, // parentIdStr: string,
+            flags,
+            baggage,
+            debugId
+        );
+    }
+
+    static withStringIds(traceIdStr: any,
+                         spanIdStr: any,
+                         parentIdStr: any,
+                         flags: number,
+                         baggage: any = {},
+                         debugId: ?string = '') : SpanContext {
+        return new SpanContext(
+            null, // traceId,
+            null, // spanId,
+            null, // parentId,
+            traceIdStr,
+            spanIdStr,
+            parentIdStr,
+            flags,
+            baggage,
+            debugId
         );
     }
 }

--- a/test/span.js
+++ b/test/span.js
@@ -41,7 +41,7 @@ describe('span should', () => {
             new ConstSampler(true)
         );
 
-        spanContext = new SpanContext(
+        spanContext = SpanContext.withBinaryIds(
             Utils.encodeInt64(1),
             Utils.encodeInt64(2),
             Utils.encodeInt64(3),

--- a/test/tracer.js
+++ b/test/tracer.js
@@ -52,7 +52,7 @@ describe('tracer should', () => {
         let spanId = Utils.encodeInt64(2);
         let parentId = Utils.encodeInt64(3);
         let flags = 1;
-        let context = new SpanContext(traceId, spanId, parentId, flags);
+        let context = SpanContext.withBinaryIds(traceId, spanId, parentId, flags);
         let start = Utils.getTimestampMicros();
         let rpcServer = false;
         let internalTags = [];
@@ -104,7 +104,7 @@ describe('tracer should', () => {
         let spanId = Utils.encodeInt64(2);
         let parentId = Utils.encodeInt64(3);
         let flags = 1;
-        let context = new SpanContext(traceId, spanId, parentId, flags);
+        let context = SpanContext.withBinaryIds(traceId, spanId, parentId, flags);
         let startTime = Utils.getTimestampMicros();
 
         let childOfParams = {
@@ -136,7 +136,7 @@ describe('tracer should', () => {
         let spanId = Utils.encodeInt64(2);
         let parentId = Utils.encodeInt64(3);
         let flags = 1;
-        let context = new SpanContext(traceId, spanId, parentId, flags);
+        let context = SpanContext.withBinaryIds(traceId, spanId, parentId, flags);
         let startTime = Utils.getTimestampMicros();
 
         let tags = {};
@@ -176,7 +176,7 @@ describe('tracer should', () => {
             keyOne: 'leela',
             keyTwo: 'bender'
         };
-        let savedContext = new SpanContext(
+        let savedContext = SpanContext.withBinaryIds(
             Utils.encodeInt64(1),
             Utils.encodeInt64(2),
             Utils.encodeInt64(3),
@@ -205,7 +205,7 @@ describe('tracer should', () => {
         let baggage = {
             keyOne: 'Leela vs. Bender',
         };
-        let savedContext = new SpanContext(
+        let savedContext = SpanContext.withBinaryIds(
             Utils.encodeInt64(1),
             Utils.encodeInt64(2),
             Utils.encodeInt64(3),
@@ -220,7 +220,7 @@ describe('tracer should', () => {
 
     it ('assert inject and extract throw errors when given an invalid format', () => {
         let carrier = {};
-        let context = new SpanContext(
+        let context = SpanContext.withBinaryIds(
             Utils.encodeInt64(1),
             Utils.encodeInt64(2),
             Utils.encodeInt64(3),


### PR DESCRIPTION
According to the basic server-client loop `benchmarks/flame_graph_loop.js` flamegraph, to/from strings ops on the span context are among the most expensive portions.  This change introduces a dual representation of trace IDs as `string` and `Buffer`. Whichever is available first is stored, and the other is only generated as needed. For most (unsampled) spans the `fromString` operation produces string IDs, and the outbound `toString` operation can use them as is, without even converting to `Buffer` representation, which is more expensive.

## To/FromString Benchmarks

The micro-benchmarks below show almost 10 times improvement for to/from string methods.

### Before benchmark

```
$ node ./benchmarks/span_context.js

Beginning Span Context Benchmark...
  2 tests completed.

  SpanContext:fromString x   274,035 ops/sec ±1.03% (90 runs sampled)
  SpanContext:toString   x 1,649,536 ops/sec ±1.01% (93 runs sampled)
```

### After benchmark

```
$ node benchmarks/span_context.js

Beginning Span Context Benchmark...
  2 tests completed.

  SpanContext:fromString x  2,463,840 ops/sec ±1.33% (91 runs sampled)
  SpanContext:toString   x 12,618,966 ops/sec ±1.21% (94 runs sampled)
```

## Core Flows Benchmarks

The `core_flow` benchmark shows moderate to no improvement

### Before benchmark

$ node benchmarks/core_flows.js

Beginning Main Request Flows...
  Fundamental Request flow with const tracer and http carrier x 41,873 ops/sec ±5.00% (73 runs sampled)
  Fundamental Request flow with const tracer and text carrier x 60,004 ops/sec ±10.43% (76 runs sampled)
  Fundamental Request flow with probabilistic tracer and http carrier x 42,920 ops/sec ±12.71% (76 runs sampled)
  Fundamental Request flow with probabilistic tracer and text carrier x 51,835 ops/sec ±28.55% (74 runs sampled)

### After benchmark

$ node benchmarks/core_flows.js

Beginning Main Request Flows...
  Fundamental Request flow with const tracer and http carrier x 47,763 ops/sec ±4.87% (75 runs sampled)
  Fundamental Request flow with const tracer and text carrier x 64,508 ops/sec ±11.43% (72 runs sampled)
  Fundamental Request flow with probabilistic tracer and http carrier x 42,601 ops/sec ±21.58% (66 runs sampled)
  Fundamental Request flow with probabilistic tracer and text carrier x 52,418 ops/sec ±33.48% (54 runs sampled)


![image](https://cloud.githubusercontent.com/assets/3523016/19296943/0b4746a4-900e-11e6-9247-d3e515c8b19f.png)
