### PR TITLE
Sample span even when it is manually passed baggage/debug-id

### DIFF
--- a/src/tracer.js
+++ b/src/tracer.js
@@ -213,6 +213,11 @@ export default class Tracer {
         if (!parent || !parent.isValid) {
             let randomId = Utils.getRandom64();
             let flags = 0;
+            if (this._sampler.isSampled()) {
+                flags |= constants.SAMPLED_MASK;
+                samplerTags = this._sampler.getTags();
+            }
+
             if (parent) {
                 if (parent.isDebugIDContainerOnly()) {
                     flags |= (constants.SAMPLED_MASK | constants.DEBUG_MASK);
@@ -220,9 +225,6 @@ export default class Tracer {
                 }
                 // baggage that could have been passed via `jaeger-baggage` header
                 ctx.baggage = parent.baggage;
-            } else if (this._sampler.isSampled()) {
-                flags |= constants.SAMPLED_MASK;
-                samplerTags = this._sampler.getTags();
             }
 
             ctx.traceId = randomId;

--- a/test/tracer.js
+++ b/test/tracer.js
@@ -63,6 +63,7 @@ describe('tracer should', () => {
 
         assert.isOk(rootSpan.context().traceId);
         assert.isNotOk(rootSpan.context().parentId);
+        assert.equal(rootSpan.context().flags, 1);
         assert.equal('Bender', rootSpan.getBaggageItem('robot'));
         assert.equal('Leela', rootSpan.getBaggageItem('female'));
         assert.equal('Fry', rootSpan.getBaggageItem('male'));


### PR DESCRIPTION
baggage context was passed to startSpan.