### PR TITLE
Re-sample the span when operationName is set after span creation

### DIFF
--- a/src/span.js
+++ b/src/span.js
@@ -152,7 +152,6 @@ export default class Span {
      * @return {Span} - returns this span.
      **/
     setOperationName(operationName: string): Span {
-        // TODO:oibe is it wrong to allow this to be set even if we are finished?
         this._operationName = operationName;
         // We re-sample the span if it has not been finalized.
         if (this._spanContext.samplingFinalized) {

--- a/src/span.js
+++ b/src/span.js
@@ -138,13 +138,6 @@ export default class Span {
 
     /**
      * Checks whether or not a span can be written to.
-     * A span is finalized when any of these happens:
-     * - it has inherited the sampling decision from its parent
-     * - its debug flag is set via the sampling.priority tag
-     * - it is finish()-ed
-     * - setOperationName is called
-     * - it is used as a parent for another span
-     * - its context is serialized using injectors
      *
      * @return {boolean} - The decision about whether this span can be written to.
      **/
@@ -274,9 +267,9 @@ export default class Span {
     _setSamplingPriority(priority: number): void {
         if (priority > 0) {
             this._spanContext.flags = this._spanContext.flags | constants.SAMPLED_MASK | constants.DEBUG_MASK;
-            this._spanContext.finalizeSampling();
         } else {
             this._spanContext.flags = this._spanContext.flags & (~constants.SAMPLED_MASK);
         }
+        this._spanContext.finalizeSampling();
     }
 }

--- a/src/span.js
+++ b/src/span.js
@@ -138,7 +138,7 @@ export default class Span {
 
     /**
      * Checks whether or not a span can be written to.
-     * A span is finalized when either of these happens:
+     * A span is finalized when any of these happens:
      * - it has inherited the sampling decision from its parent
      * - its debug flag is set via the sampling.priority tag
      * - it is finish()-ed
@@ -168,7 +168,7 @@ export default class Span {
 
         let sampler = this.tracer()._sampler;
         let tags = {};
-        if (!this._spanContext._samplingFinalized && sampler.isSampled(operationName, tags)) {
+        if (sampler.isSampled(operationName, tags)) {
             this._spanContext.flags |= constants.SAMPLED_MASK;
             this.addTags(tags);
         }

--- a/src/span_context.js
+++ b/src/span_context.js
@@ -43,8 +43,9 @@ export default class SpanContext {
      * it in the case that an operation name is set after span creation. Situations 
      * where a span context's sampling decision is finalized include:
      * 1.)  Finishing the span.
-     * 2.)  Using the span context as a parent when beginning a new span.
-     * 3.)  Setting the operation name on the span.
+     * 2.)  Extracting the span context from the wire format.
+     * 3.)  A span that was created wth a parent span context.
+     * 4.)  Setting the operation name on the span.
      * */
     _samplingFinalized: boolean;
 
@@ -155,12 +156,12 @@ export default class SpanContext {
         this._debugId = debugId;
     }
 
-    set samplingFinalized(finished: boolean) {
-        this._samplingFinalized = finished;
-    }
-
     get isValid(): boolean {
         return !!((this._traceId || this._traceIdStr) && (this._spanId || this._spanIdStr));
+    }
+
+    finalizeSampling(): void {
+        this._samplingFinalized = true;
     }
 
     isDebugIDContainerOnly(): boolean {

--- a/src/span_context.js
+++ b/src/span_context.js
@@ -33,6 +33,7 @@ export default class SpanContext {
     _flags: number;
     _baggage: any;
     _debugId: ?string;
+    _samplingFinished: boolean;
 
     constructor(traceId: any,
                 spanId: any,
@@ -42,7 +43,8 @@ export default class SpanContext {
                 parentIdStr: ?string,
                 flags: number = 0,
                 baggage: any = {},
-                debugId: ?string = '') {
+                debugId: ?string = '',
+                samplingFinished: boolean = false) {
         this._traceId = traceId;
         this._spanId = spanId;
         this._parentId = parentId;
@@ -52,6 +54,7 @@ export default class SpanContext {
         this._flags = flags;
         this._baggage = baggage;
         this._debugId = debugId;
+        this._samplingFinished = samplingFinished;
     }
 
     get traceId(): any {
@@ -108,6 +111,10 @@ export default class SpanContext {
         return this._debugId;
     }
 
+    get samplingFinished(): boolean {
+        return this._samplingFinished;
+    }
+
     set traceId(traceId: Buffer): void {
         this._traceId = traceId;
         this._traceIdStr = null;
@@ -133,6 +140,10 @@ export default class SpanContext {
 
     set debugId(debugId: ?string): void {
         this._debugId = debugId;
+    }
+
+    set samplingFinished(finished: boolean) {
+        this._samplingFinished = finished;
     }
 
     get isValid(): boolean {
@@ -169,7 +180,9 @@ export default class SpanContext {
             this._parentIdStr,
             this._flags,
             newBaggage,
-            this._debugId);
+            this._debugId,
+            this._samplingFinished
+            );
     }
 
     /**

--- a/src/span_context.js
+++ b/src/span_context.js
@@ -38,7 +38,7 @@ export default class SpanContext {
      * correlated operation name -> sampling rate mapping, and when it cannot.
      * Adaptive sampling uses the operation name of a span to correlate it with
      * a sampling rate.  If an operation name is set on a span after the span's creation
-     * then adaptive sampling can no long connect the name to the proper sampling rate.
+     * then adaptive sampling cannot associate the operation name with the proper sampling rate.
      * In order to correct this we allow a span to be written to, so that we can re-sample
      * it in the case that an operation name is set after span creation. Situations 
      * where a span context's sampling decision is finalized include:

--- a/src/span_context.js
+++ b/src/span_context.js
@@ -42,10 +42,12 @@ export default class SpanContext {
      * In order to correct this we allow a span to be written to, so that we can re-sample
      * it in the case that an operation name is set after span creation. Situations 
      * where a span context's sampling decision is finalized include:
-     * 1.)  Finishing the span.
-     * 2.)  Extracting the span context from the wire format.
-     * 3.)  A span that was created with a parent span context.
-     * 4.)  Setting the operation name on the span.
+     * - it has inherited the sampling decision from its parent
+     * - its debug flag is set via the sampling.priority tag
+     * - it is finish()-ed
+     * - setOperationName is called
+     * - it is used as a parent for another span
+     * - its context is serialized using injectors
      * */
     _samplingFinalized: boolean;
 

--- a/src/span_context.js
+++ b/src/span_context.js
@@ -44,7 +44,7 @@ export default class SpanContext {
      * where a span context's sampling decision is finalized include:
      * 1.)  Finishing the span.
      * 2.)  Extracting the span context from the wire format.
-     * 3.)  A span that was created wth a parent span context.
+     * 3.)  A span that was created with a parent span context.
      * 4.)  Setting the operation name on the span.
      * */
     _samplingFinalized: boolean;

--- a/src/tracer.js
+++ b/src/tracer.js
@@ -237,8 +237,6 @@ export default class Tracer {
             // reuse parent's baggage as we'll never change it
             ctx.baggage = parent.baggage;
 
-            // Whenever a span context is the child of or a reference used for creating another span
-            // then the child span's context must be finalized.
             parent.finalizeSampling();
             ctx.finalizeSampling();
         }
@@ -267,6 +265,10 @@ export default class Tracer {
      *         for a description of the carrier object.
      **/
     inject(spanContext: SpanContext, format: string, carrier: any): void {
+        if (!spanContext) {
+            return;
+        }
+
         let injector = this._injectors[format];
         if (!injector) {
             throw new Error(`Unsupported format: ${format}`);
@@ -276,10 +278,8 @@ export default class Tracer {
             spanContext = spanContext.context();
         }
 
-        if (spanContext) {
-            spanContext.finalizeSampling();
-            injector.inject(spanContext, carrier);
-        }
+        spanContext.finalizeSampling();
+        injector.inject(spanContext, carrier);
     }
 
     /**

--- a/src/tracer.js
+++ b/src/tracer.js
@@ -239,6 +239,7 @@ export default class Tracer {
 
             // Whenever a span context is the child of or a reference used for creating another span
             // then the child span's context must be finalized.
+            parent.finalizeSampling();
             ctx.finalizeSampling();
         }
 
@@ -271,15 +272,14 @@ export default class Tracer {
             throw new Error(`Unsupported format: ${format}`);
         }
 
-        // Here because opentracing api compatibility tests can pass
-        // either span or span context.  Calling finalizeSampling below
-        // only works on a span context.
         if (spanContext.context) {
             spanContext = spanContext.context();
         }
 
-        spanContext.finalizeSampling();
-        injector.inject(spanContext, carrier);
+        if (spanContext) {
+            spanContext.finalizeSampling();
+            injector.inject(spanContext, carrier);
+        }
     }
 
     /**
@@ -300,7 +300,6 @@ export default class Tracer {
 
         let spanContext = extractor.extract(carrier);
 
-        // spanContext can be null if using a differnt type of extractor. i.e. BinaryCodec
         if (spanContext) {
             spanContext.finalizeSampling();
         }

--- a/src/tracer.js
+++ b/src/tracer.js
@@ -202,6 +202,11 @@ export default class Tracer {
                 }
             }
         }
+        // Whenever a span context is the child of or a reference used for creating another span
+        // then the parent span context must be finalized.
+        if (parent) {
+            parent.samplingFinalized = true;
+        }
 
         let spanKindValue = userTags[opentracing_tags.SPAN_KIND];
         let rpcServer = (spanKindValue === opentracing_tags.SPAN_KIND_RPC_SERVER);
@@ -267,6 +272,7 @@ export default class Tracer {
             throw new Error(`Unsupported format: ${format}`);
         }
 
+        spanContext.samplingFinalized = true;
         injector.inject(spanContext, carrier);
     }
 

--- a/test/span.js
+++ b/test/span.js
@@ -228,9 +228,13 @@ describe('span should', () => {
             it ('set the sampling priority to enable debug', () => {
                 span.setTag(opentracing.Tags.SAMPLING_PRIORITY, 1);
                 assert.isOk(span.context().samplingFinalized);
+
+                let unsampledSpan = tracer.startSpan('usampled-span');
+                unsampledSpan.setTag(opentracing.Tags.SAMPLING_PRIORITY, -1);
+                assert.isOk(unsampledSpan.context().samplingFinalized);
             });
 
-            it ('has finished', () => {
+            it ('have finished', () => {
                 span.finish();
                 assert.isOk(span.context().samplingFinalized);
             });
@@ -256,12 +260,14 @@ describe('span should', () => {
                 { logger: new MockLogger() }
             );
             let unFinalizedSpan = tracer.startSpan('unFinalizedSpan');
-
             assert.isOk(unFinalizedSpan._isWriteable());
-            assert.isOk(span._isWriteable());
+
+            tracer._sampler = new ConstSampler(true);
+            let sampledSpan = tracer.startSpan('sampled-span');
+            assert.isOk(sampledSpan._isWriteable());
         });
 
-        it ('setOperationName should add sampler tags to span, and change operationName', () => {
+        it ('2nd setOperationName should add sampler tags to span, and change operationName', () => {
             let span = tracer.startSpan('fry');
 
             assert.equal(span.operationName, 'fry');
@@ -279,7 +285,7 @@ describe('span should', () => {
             }));
         });
 
-        it ('setOperationName should not change the sampling tags, but should change the operationName', () => {
+        it ('2nd setOperationName should not change the sampling tags, but should change the operationName', () => {
             let span = tracer.startSpan('fry');
 
             span.setOperationName('new-span-one');


### PR DESCRIPTION
This preserves adaptive sampling by allowing a proper operationName
to be correlated with the correct sampling rate (eventhough the
sampling decision has already happened.)