### PR TITLE
Accept external timestamps in milliseconds since epoch

### DIFF
--- a/src/thrift.js
+++ b/src/thrift.js
@@ -83,7 +83,7 @@ export default class ThriftUtils {
         for (let i = 0; i < logs.length; i++) {
             let log = logs[i];
             thriftLogs.push({
-                'timestamp': log.timestamp,
+                'timestamp': Utils.encodeInt64(log.timestamp * 1000), // to microseconds
                 'fields': ThriftUtils.getThriftTags(log.fields)
             });
         }
@@ -130,8 +130,8 @@ export default class ThriftUtils {
             operationName: span._operationName,
             references: ThriftUtils.spanRefsToThriftRefs(span._references),
             flags: span._spanContext.flags,
-            startTime: Utils.encodeInt64(span._startTime),
-            duration: Utils.encodeInt64(span._duration),
+            startTime: Utils.encodeInt64(span._startTime * 1000), // to microseconds
+            duration: Utils.encodeInt64(span._duration * 1000), // to microseconds
             tags: tags,
             logs: logs
         }

--- a/src/tracer.js
+++ b/src/tracer.js
@@ -174,10 +174,7 @@ export default class Tracer {
         let references = options.references || [];
 
         let userTags = options.tags || {};
-        let startTime = options.startTime;
-        if (!startTime) {
-            startTime = Utils.getTimestampMicros();
-        }
+        let startTime = options.startTime || this.now();
 
         // This flag is used to ensure that CHILD_OF reference is preferred 
         // as a parent even if it comes after FOLLOWS_FROM reference.
@@ -313,5 +310,16 @@ export default class Tracer {
         reporter.close(() => {
             this._sampler.close(callback);
         });
+    }
+
+    /**
+     * Returns the current timestamp in milliseconds since the Unix epoch.
+     * Fractional values are allowed so that timestamps with sub-millisecond
+     * accuracy can be represented.
+     */
+    now(): number {
+        // TODO investigate process.hrtime; verify it is available in all Node versions.
+        // http://stackoverflow.com/questions/11725691/how-to-get-a-microtime-in-node-js
+        return Date.now();
     }
 }

--- a/src/util.js
+++ b/src/util.js
@@ -102,16 +102,6 @@ export default class Utils {
         return input.substring(counter);
     }
 
-    /**
-     * Returns the timestamp in microseconds.
-     * @return {number} - The microseconds since the epoch.
-     **/
-    static getTimestampMicros(): number {
-        // TODO(oibe) investigate process.hrtime.  I'm not sure if its in all node versions.
-        // http://stackoverflow.com/questions/11725691/how-to-get-a-microtime-in-node-js
-        return Date.now() * 1000;
-    }
-
     static myIp(): string {
         let myIp = '0.0.0.0';
         let ifaces = os.networkInterfaces();

--- a/test/span.js
+++ b/test/span.js
@@ -58,7 +58,7 @@ describe('span should', () => {
             tracer,
             'op-name',
             spanContext,
-            Utils.getTimestampMicros()
+            tracer.now()
         );
     });
 
@@ -149,14 +149,14 @@ describe('span should', () => {
     });
 
     it('add logs with event, but without timestamp', () => {
-        let expectedTimestamp = new Date(2016, 8, 12).getTime();
+        let expectedTimestamp = 123.456;
         // mock global clock
         let clock = sinon.useFakeTimers(expectedTimestamp);
         let event = 'some messgae';
         span.log({ event });
 
         assert.equal(span._logs.length, 1);
-        assert.equal(span._logs[0].timestamp, expectedTimestamp * 1000); // to micros
+        assert.equal(span._logs[0].timestamp, expectedTimestamp);
         assert.equal(span._logs[0].fields[0].value, event);
         clock.restore();
     });

--- a/test/test_util.js
+++ b/test/test_util.js
@@ -106,7 +106,7 @@ describe('TestUtils', () => {
             'log2_key': 'some-log-value2'
         };
 
-        let timestamp = Utils.getTimestampMicros();
+        let timestamp = Date.now();
 
         span.log(log1, timestamp);
         span.log(log2, timestamp);

--- a/test/thrift.js
+++ b/test/thrift.js
@@ -51,7 +51,7 @@ describe ('ThriftUtils', () => {
         assert.isOk(deepEqual(ThriftUtils.emptyBuffer, buf));
     });
 
-    it ('should conver timestamps to microseconds', () => {
+    it ('should convert timestamps to microseconds', () => {
         let reporter = new InMemoryReporter();
         let tracer = new Tracer(
             'test-service-name',

--- a/test/thrift.js
+++ b/test/thrift.js
@@ -21,10 +21,14 @@
 import {assert} from 'chai';
 import deepEqual from 'deep-equal';
 import Long from 'long';
+import ConstSampler from '../src/samplers/const_sampler.js';
+import InMemoryReporter from '../src/reporters/in_memory_reporter.js';
+import Tracer from '../src/tracer.js';
 import ThriftUtils from '../src/thrift.js';
+import Utils from '../src/util.js';
 
-describe ('ThriftUtils should', () => {
-    it ('exercise all paths in getTagType', () => {
+describe ('ThriftUtils', () => {
+    it ('should exercise all paths in getTagType', () => {
         let tags = ThriftUtils.getThriftTags([
             {'key': 'double', 'value': 1.0 },
             {'key': 'boolean', 'value': true },
@@ -40,10 +44,27 @@ describe ('ThriftUtils should', () => {
         assert.equal(tags[4].vType, 'STRING');
     });
 
-    it ('initialize emptyBuffer to all zeros', () => {
+    it ('should initialize emptyBuffer to all zeros', () => {
         let buf = new Buffer(8);
         buf.fill(0);
 
         assert.isOk(deepEqual(ThriftUtils.emptyBuffer, buf));
+    });
+
+    it ('should conver timestamps to microseconds', () => {
+        let reporter = new InMemoryReporter();
+        let tracer = new Tracer(
+            'test-service-name',
+            reporter,
+            new ConstSampler(true)
+        );
+        let span = tracer.startSpan('some operation', { startTime: 123.456 });
+        span.log({ event: 'some log' }, 123.567);
+        span.finish(123.678);
+        tracer.close();
+        let tSpan = ThriftUtils.spanToThrift(span);
+        assert.deepEqual(tSpan.startTime, Utils.encodeInt64(123456));
+        assert.deepEqual(tSpan.duration, Utils.encodeInt64((123.678-123.456) * 1000));
+        assert.deepEqual(tSpan.logs[0].timestamp, Utils.encodeInt64(123567));
     });
 });

--- a/test/tracer.js
+++ b/test/tracer.js
@@ -75,7 +75,7 @@ describe('tracer should', () => {
         let parentId = Utils.encodeInt64(3);
         let flags = 1;
         let context = SpanContext.withBinaryIds(traceId, spanId, parentId, flags);
-        let start = Utils.getTimestampMicros();
+        let start = 123.456;
         let rpcServer = false;
         let internalTags = [];
         let references = [];
@@ -126,17 +126,17 @@ describe('tracer should', () => {
         let parentId = Utils.encodeInt64(3);
         let flags = 1;
         let context = SpanContext.withBinaryIds(traceId, spanId, parentId, flags);
-        let startTime = Utils.getTimestampMicros();
+        let startTime = 123.456;
 
         let childOfParams = {
             operationName: 'test-name',
             childOf: context,
-            startTime, startTime
+            startTime: startTime
         };
 
         let referenceParams = {
             operationName: 'test-name',
-            startTime, startTime,
+            startTime: startTime,
             references: [new opentracing.Reference(opentracing.REFERENCE_CHILD_OF, context)],
         };
 


### PR DESCRIPTION
opentracing-javascript API states that external timestamps can be passed expressed in milliseconds since epoch. We can convert to microseconds only when reporting to the backend.