### PR TITLE
Make Configuration accept MetricsFactory, not Metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,17 @@ sh --registry=https://registry.npmjs.org
 Changes by Version
 ==================
 
-3.2.2 (Unreleased)
+3.3.0 (Unreleased)
 ------------------
 
-- No changes yet
+- Make Configuration accept MetricsFactory, not Metrics
 
 
 3.2.1 (2017-02-08)
 -------------------
 - Make sure initTracer passes options to the tracer
 - Do not wrap single RemoteReporter into CompositeReporter
+
 
 3.2.0 (2017-02-04)
 -------------------
@@ -25,6 +26,7 @@ Changes by Version
 - Remove `hasLogs` method that was not particularly useful in practice because it compared the timestamp
 - Accept external timestamps in milliseconds since epoch (#94)
 - Expose TChannelBridge.inject method (#93)
+
 
 3.1.0 (2017-02-02)
 -------------------

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jaeger-client",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "description": "Jaeger binding for OpenTracing Node",
   "license": "MIT",
   "keywords": [],

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -28,6 +28,7 @@ import RemoteReporter from './reporters/remote_reporter';
 import CompositeReporter from './reporters/composite_reporter';
 import LoggingReporter from './reporters/logging_reporter';
 import RemoteSampler from './samplers/remote_sampler';
+import Metrics from './metrics/metrics';
 import Tracer from './tracer';
 import UDPSender from './reporters/udp_sender';
 import opentracing from 'opentracing';
@@ -148,8 +149,8 @@ export default class Configuration {
      * @param {Object} [options.reporter] - if provided, this reporter will be used.
      *        Otherwise a new reporter will be created according to the description
      *        in the config.
-     * @param {Object} [options.metrics] - instance of the Metrics class from ./metrics/metrics.js.
-     * @param {Object} [options.logger] - - a logger matching NullLogger API from ./logger.js.
+     * @param {Object} [options.metrics] - a metrics factory (see ./_flow/metrics.js)
+     * @param {Object} [options.logger] - a logger (see ./_flow/logger.js)
      * @param {Object} [options.tags] - set of key-value pairs which will be set
      *        as process-level tags on the Tracer itself.
      */
@@ -179,12 +180,17 @@ export default class Configuration {
             );
         }
 
+        var metrics = null;
+        if (options.metrics) {
+            metrics = new Metrics(options.metrics);
+        }
+
         return new Tracer(
             config.serviceName,
             reporter,
             sampler,
             {
-                metrics: options.metrics,
+                metrics: metrics,
                 logger: options.logger,
                 tags: options.tags
             }

--- a/test/init_tracer.js
+++ b/test/init_tracer.js
@@ -138,17 +138,22 @@ describe('initTracer', () => {
         var logger = {
             'info': function info(msg){}
         };
+        var metrics = {
+            'createCounter': function createCounter() { return {}; },
+            'createGauge': function createGauge() { return {}; },
+            'createTimer': function createTimer() { return {}; },
+        };
         let tracer = initTracer({
             serviceName: 'test-service'
         }, {
             logger: logger,
-            metrics: 'some metrics',
+            metrics: metrics,
             tags: {
                 'x': 'y'
             }
         });
         assert.equal(tracer._logger, logger);
-        assert.equal(tracer._metrics, 'some metrics');
+        assert.equal(tracer._metrics._factory, metrics);
         assert.equal(tracer._tags['x'], 'y');
     });
 });


### PR DESCRIPTION
Metrics is an internal class, MetricsFactory is what we expect users to provide.