### PR TITLE
Add support for deferred sampling

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -24,6 +24,11 @@ export const SAMPLED_MASK = 0x1;
 // DEBUG_MASK is the bit mask indicationg that a span has been marked for debug.
 export const DEBUG_MASK = 0x2;
 
+// DEFERRED_SAMPLING_MASK is the bit mask indicating that the upstream service that generated the
+// span did not make a definitive sampling decision, but deferred it to be made by some
+// downstream service.
+export const DEFERRED_SAMPLING_MASK = 0x4;
+
 // JAEGER_CLIENT_VERSION_TAG_KEY is the name of the tag used to report client version.
 export const JAEGER_CLIENT_VERSION_TAG_KEY = 'jaeger.version';
 

--- a/src/span_context.js
+++ b/src/span_context.js
@@ -166,7 +166,7 @@ export default class SpanContext {
     }
 
     unsetDeferredSampling(): void {
-        this._flags &= ~constants.DEFERRED_SAMPLING_MASK
+        this._flags &= ~constants.DEFERRED_SAMPLING_MASK;
     }
 
     finalizeSampling(): void {

--- a/src/span_context.js
+++ b/src/span_context.js
@@ -161,6 +161,14 @@ export default class SpanContext {
         return !!((this._traceId || this._traceIdStr) && (this._spanId || this._spanIdStr));
     }
 
+    get isDeferredSampling(): boolean {
+        return (this._flags & constants.DEFERRED_SAMPLING_MASK) === constants.DEFERRED_SAMPLING_MASK;
+    }
+
+    unsetDeferredSampling(): void {
+        this._flags &= ~constants.DEFERRED_SAMPLING_MASK
+    }
+
     finalizeSampling(): void {
         this._samplingFinalized = true;
     }


### PR DESCRIPTION
- When a downstream service doesn't have enough information to
  make a sampling decision, it sets the span context flag 4.

- When a span with the flag 4 is encountered, a sampling decision
  for any child spans is made based on the current operation name
  instead of depending on the sampling decision on the parent if
  the span context doesn't contain the debug flag(2). Debug spans
  are always sampled.