### PR TITLE
Bump jaeger idl

### DIFF
--- a/crossdock/test/endtoend_handler.js
+++ b/crossdock/test/endtoend_handler.js
@@ -40,8 +40,9 @@ describe('Endtoend Handler should', () => {
         server = dgram.createSocket('udp4');
         server.bind(PORT, HOST);
         thrift = new Thrift({
-            source: fs.readFileSync(path.join(__dirname, '../../src/jaeger-idl/thrift/jaeger.thrift'), 'ascii'),
-            allowOptionalArguments: true
+            source: fs.readFileSync(path.join(__dirname, '../../src/thriftrw-idl/agent.thrift'), 'ascii'),
+            allowOptionalArguments: true,
+            allowFilesystemAccess: true
         });
 
         let handler = new EndToEndHandler({port: PORT, host: HOST});

--- a/src/thriftrw-idl/agent.thrift
+++ b/src/thriftrw-idl/agent.thrift
@@ -1,0 +1,39 @@
+# The MIT License (MIT)
+# 
+# Copyright (c) 2017 Uber Technologies, Inc.
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+# For thriftrw to work, include paths must be prefixed with ./ or ../
+# This agent.thrift file is a copy of jaeger-idl/thrift/agent.thrift with
+# a few alterations:
+#
+# 1) zipkin.thrift was completely removed given that jaeger-idl/thrift/zipkincore.thrift
+#    doesn't conform to thriftrw specifications.
+# 2) changed the path to jaeger.thrift
+#
+# Unfortunately, this file needs to be kept up to date manually.
+
+include "./src/jaeger-idl/thrift/jaeger.thrift"
+
+namespace java com.uber.jaeger.agent.thrift
+
+service Agent {
+    oneway void emitBatch(1: jaeger.Batch batch)
+}

--- a/test/udp_sender.js
+++ b/test/udp_sender.js
@@ -64,8 +64,9 @@ describe('udp sender should', () => {
         sender = new UDPSender();
         sender.setProcess(reporter._process);
         thrift = new Thrift({
-            source: fs.readFileSync(path.join(__dirname, '../src/jaeger-idl/thrift/jaeger.thrift'), 'ascii'),
-            allowOptionalArguments: true
+            source: fs.readFileSync(path.join(__dirname, '../src/thriftrw-idl/agent.thrift'), 'ascii'),
+            allowOptionalArguments: true,
+            allowFilesystemAccess: true
         });
     });
 


### PR DESCRIPTION
Bumping jaeger-idl broke some things. Before `jaeger.idl` had the emitBatch function but it was moved to `agent.idl`; however, `agent.idl` is not thriftrw compatible.

I added a new `agent.idl` that's thriftrw compatible, but it has to be manually updated to keep up to date. The thriftrw idl could be moved to jaeger-idl repo however it's only nodejs specific.  