### PR TITLE
Copy thriftrw-idl to dist, fix include, init via entryPoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ build-node: node_modules
 	cp package.json ./dist/
 	cp -R ./src/jaeger-idl ./dist/src/
 	rm -rf ./dist/src/jaeger-idl/.git
+	cp -R ./src/thriftrw-idl ./dist/src/
 
 .PHONY: node_modules
 node_modules:

--- a/crossdock/test/endtoend_handler.js
+++ b/crossdock/test/endtoend_handler.js
@@ -40,7 +40,7 @@ describe('Endtoend Handler should', () => {
         server = dgram.createSocket('udp4');
         server.bind(PORT, HOST);
         thrift = new Thrift({
-            source: fs.readFileSync(path.join(__dirname, '../../src/thriftrw-idl/agent.thrift'), 'ascii'),
+            entryPoint: path.join(__dirname, '../../src/thriftrw-idl/agent.thrift'),
             allowOptionalArguments: true,
             allowFilesystemAccess: true
         });

--- a/src/reporters/udp_sender.js
+++ b/src/reporters/udp_sender.js
@@ -54,7 +54,7 @@ export default class UDPSender {
             this._logger.error(`error sending spans over UDP: ${err}`)
         })
         this._agentThrift = new Thrift({
-            source: fs.readFileSync(path.join(__dirname, '../thriftrw-idl/agent.thrift'), 'ascii'),
+            entryPoint: path.join(__dirname, '../thriftrw-idl/agent.thrift'),
             allowOptionalArguments: true,
             allowFilesystemAccess: true
         });

--- a/src/thriftrw-idl/agent.thrift
+++ b/src/thriftrw-idl/agent.thrift
@@ -1,17 +1,17 @@
 # The MIT License (MIT)
-# 
+#
 # Copyright (c) 2017 Uber Technologies, Inc.
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -30,7 +30,7 @@
 #
 # Unfortunately, this file needs to be kept up to date manually.
 
-include "./src/jaeger-idl/thrift/jaeger.thrift"
+include "../jaeger-idl/thrift/jaeger.thrift"
 
 namespace java com.uber.jaeger.agent.thrift
 

--- a/test/udp_sender.js
+++ b/test/udp_sender.js
@@ -67,7 +67,7 @@ describe('udp sender should', () => {
         sender = new UDPSender();
         sender.setProcess(reporter._process);
         thrift = new Thrift({
-            source: fs.readFileSync(path.join(__dirname, '../src/thriftrw-idl/agent.thrift'), 'ascii'),
+            entryPoint: path.join(__dirname, '../src/thriftrw-idl/agent.thrift'),
             allowOptionalArguments: true,
             allowFilesystemAccess: true
         });


### PR DESCRIPTION
Fix #155.

- Fix include in `thriftrw-idl/agent.thrift` to assume PWD is the location of the `agent.thrift`
- Init `thriftrw-idl/agent.thrift` via entryPoint (updated tests, too)
- Copy `thriftrw-idl/agent.thrift` to dist when building


